### PR TITLE
feat: publish to ghcr

### DIFF
--- a/.github/workflows/build-and-deploy-container.yaml
+++ b/.github/workflows/build-and-deploy-container.yaml
@@ -52,10 +52,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build Docker Image
-        run: docker build -t ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG} .
+        run: |
+          docker build -t ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG} .
+          docker build -t ghcr.io/${GITHUB_REPOSITORY}:${{ steps.get_calver.outputs.CalVer }} .
       - name: Login to GHCR
         run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
       - name: Push Docker Image
         run: |
-          docker push ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}
+          docker push ghcr.io/${GITHUB_REPOSITORY}:latest
           docker push ghcr.io/${GITHUB_REPOSITORY}:${{ steps.get_calver.outputs.CalVer }}

--- a/.github/workflows/build-and-deploy-container.yaml
+++ b/.github/workflows/build-and-deploy-container.yaml
@@ -11,7 +11,7 @@ defaults:
   run:
     shell: bash
 jobs:
-  build-linux-box:
+  build-linux-box-dockerhub:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -37,3 +37,25 @@ jobs:
           tags: |
             ajkayalan/docker-linux-dev-box:latest
             ajkayalan/docker-linux-dev-box:${{ steps.get_calver.outputs.CalVer }}
+  build-linux-box-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Get CalVer
+        id: get_calver
+        run: |
+          CalVer=$(date '+%Y.%m.%d')
+          echo "::set-output name=CalVer::$CalVer"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build Docker Image
+        run: docker build -t ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG} .
+      - name: Login to GHCR
+        run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+      - name: Push Docker Image
+        run: |
+          docker push ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}
+          docker push ghcr.io/${GITHUB_REPOSITORY}:${{ steps.get_calver.outputs.CalVer }}


### PR DESCRIPTION
Publish image to GHCR.

FWIW I have not moved my workflows to use `GITHUB_TOKEN` yet for this but should work according to: https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/